### PR TITLE
Check valid guest address when parsing /proc/self/maps

### DIFF
--- a/accel/tcg/cpu-exec.c
+++ b/accel/tcg/cpu-exec.c
@@ -198,7 +198,7 @@ static void collect_memory_snapshot(void) {
                     " %512s", &min, &max, &flag_r, &flag_w, &flag_x,
                     &flag_p, &offset, &dev_maj, &dev_min, &inode, path);
 
-    if ((fields < 10) || (fields > 11))
+    if ((fields < 10) || (fields > 11) || !h2g_valid(min))
         continue;
     
     int flags = page_get_flags(h2g(min));
@@ -425,7 +425,7 @@ void afl_setup(void) {
                         " %512s", &min, &max, &flag_r, &flag_w, &flag_x,
                         &flag_p, &offset, &dev_maj, &dev_min, &inode, path);
 
-        if (!flag_x || (fields < 10) || (fields > 11))
+        if ((fields < 10) || (fields > 11) || !flag_x || !h2g_valid(min))
             continue;
         
         int flags = page_get_flags(h2g(min));


### PR DESCRIPTION
Simple check to ignore memory regions whose start address does not belong to guest address space when parsing /proc/self/maps.

Without this, qemuafl crashes in the next `h2g(min)` when `min` doesn't belong to guest address space, which happens for example on a 32 bits target and a 64 bits system.