### PR TITLE
Fix persistent mode on 32-bit target on 64-bit host

### DIFF
--- a/qemuafl/cpu-translate.h
+++ b/qemuafl/cpu-translate.h
@@ -35,7 +35,7 @@
 #include "tcg/tcg.h"
 #include "tcg/tcg-op.h"
 
-#if TCG_TARGET_REG_BITS == 64
+#if TARGET_LONG_BITS == 64
   #define _DEFAULT_MO MO_64
 #else
   #define _DEFAULT_MO MO_32


### PR DESCRIPTION
The value of `_DEFAULT_MO` is set according to `TCG_TARGET_REG_BITS`, which stands for the bits of the **host** architecture, according to [this](https://github.com/AFLplusplus/qemuafl/blob/3ed38f9a6e0af4ccc2f8b3efb577a4f3fb6a3a2b/tcg/README#L16). Instead, use `TARGET_LONG_BITS`, which is the bits of the **emulated** architecture.

This fixes [#570](https://github.com/AFLplusplus/AFLplusplus/issues/570) (tcg fatal error at `tcg_canonicalize_memop`) and avoids having to specify AFL_QEMU_PERSISTENT_RET even when AFL_QEMU_PERSISTENT_ADDR points to the start of a function.
