### PR TITLE
Mispelled atomic operations

### DIFF
--- a/accel/tcg/cpu-exec.c
+++ b/accel/tcg/cpu-exec.c
@@ -877,7 +877,7 @@ afl_tb_lookup(CPUState *cpu, target_ulong pc, target_ulong cs_base,
     uint32_t hash;
 
     hash = tb_jmp_cache_hash_func(pc);
-    tb = atomic_rcu_read(&cpu->tb_jmp_cache[hash]);
+    tb = qatomic_rcu_read(&cpu->tb_jmp_cache[hash]);
 
     cf_mask &= ~CF_CLUSTER_MASK;
     cf_mask |= cpu->cluster_index << CF_CLUSTER_SHIFT;
@@ -894,7 +894,7 @@ afl_tb_lookup(CPUState *cpu, target_ulong pc, target_ulong cs_base,
     if (tb == NULL) {
         return NULL;
     }
-    atomic_set(&cpu->tb_jmp_cache[hash], tb);
+    qatomic_set(&cpu->tb_jmp_cache[hash], tb);
     return tb;
 }
 

--- a/accel/tcg/translate-all.c
+++ b/accel/tcg/translate-all.c
@@ -1782,7 +1782,7 @@ TranslationBlock *afl_gen_edge(CPUState *cpu, unsigned long afl_id)
     }
     tb->tc.size = gen_code_size;
 
-    atomic_set(&tcg_ctx->code_gen_ptr, (void *)
+    qatomic_set(&tcg_ctx->code_gen_ptr, (void *)
         ROUND_UP((uintptr_t)gen_code_buf + gen_code_size + search_size,
                  CODE_GEN_ALIGN));
 


### PR DESCRIPTION
Ciao @andreafioraldi,

I got some undefined references during build that I traced back to a couple of wrongly/mispelled calls to atomic operations.

Keep rocking!