### PR TITLE
fix bug in arm & arm64 persistence mode when GPR saving enabled

### DIFF
--- a/qemuafl/api.h
+++ b/qemuafl/api.h
@@ -20,7 +20,7 @@ struct x86_regs {
     uint32_t flags;
   };
   
-  uint8_t xmm_regs[16][8];
+  uint8_t xmm_regs[8][16];
 
 };
 
@@ -42,7 +42,7 @@ struct x86_64_regs {
     uint64_t flags;
   };
   
-  uint8_t zmm_regs[64][32];
+  uint8_t zmm_regs[32][64];
 
 };
 

--- a/qemuafl/api.h
+++ b/qemuafl/api.h
@@ -73,7 +73,7 @@ struct arm_regs {
   
   uint32_t cpsr;
 
-  uint8_t vfp_zregs[16][32];
+  uint8_t vfp_zregs[32][16];
   uint32_t vfp_xregs[16];
 
 };
@@ -131,8 +131,8 @@ struct arm64_regs {
   
   uint32_t cpsr;
 
-  uint8_t vfp_zregs[16 * 16][32];
-  uint8_t vfp_pregs[32][17];
+  uint8_t vfp_zregs[32][16*16];
+  uint8_t vfp_pregs[17][32];
   uint32_t vfp_xregs[16];
 
 };


### PR DESCRIPTION
There is a OOB read and write during GPR registers saving and restoring (funcs `afl_restore_regs` and `afl_save_regs`).

At [afl_save_regs, line 128 of file](../blob/master/target/arm/translate.c#L128) we iterate over 32 registers in a way `r->vfp_zregs[i]`, but according declaration the first level array has only 16 items (for ARM and 256 for aarch64). Even more later we copy register with size `sizeof(r->vfp_zregs[i])` and it equals to 32, but should be 16 for ARM and 256 for aarch64. The same bug occurs in `afl_restore_regs` and when saving/restoring `vfp_pregs` registers.

So I've changed declarations of `arm_regs` and `arm64_regs` and this piece of code works correctly now.