### PR TITLE
run afl_persistent_hook AFTER child resume

### DIFF
--- a/accel/tcg/cpu-exec.c
+++ b/accel/tcg/cpu-exec.c
@@ -736,18 +736,8 @@ void afl_persistent_iter(CPUArchState *env) {
   
     if (persistent_memory) restore_memory_snapshot();
   
-    if (persistent_save_gpr) {
-    
-      if (afl_persistent_hook_ptr) {
-      
-        struct api_regs hook_regs = saved_regs;
-        afl_persistent_hook_ptr(&hook_regs, guest_base, shared_buf,
-                                *shared_buf_len);
-        afl_restore_regs(&hook_regs, env);
-
-      } else
-        afl_restore_regs(&saved_regs, env);
-      
+    if (persistent_save_gpr && !afl_persistent_hook_ptr) {
+      afl_restore_regs(&saved_regs, env);
     }
 
     if (!disable_caching) {
@@ -768,6 +758,17 @@ void afl_persistent_iter(CPUArchState *env) {
 
     // TODO use only pipe
     raise(SIGSTOP);
+
+    
+    // now we have shared_buf updated and ready to use
+    if (persistent_save_gpr && afl_persistent_hook_ptr) {
+    
+      struct api_regs hook_regs = saved_regs;
+      afl_persistent_hook_ptr(&hook_regs, guest_base, shared_buf,
+                              *shared_buf_len);
+      afl_restore_regs(&hook_regs, env);
+
+    }
 
     afl_area_ptr[0] = 1;
     afl_prev_loc = 0;


### PR DESCRIPTION
One more fix if you don't mind)

When `AFL_QEMU_PERSISTENT_GPR=1` and `AFL_QEMU_PERSISTENT_HOOK` is set, we have to `SIGSTOP` fuzzed child **before** calling `afl_persistent_hook_ptr`. Otherwise in `afl_persistent_hook_ptr` we'll process previous input (new input will be generated by parent only after receiving `SIGSTOP` from fuzzed child) and finally a wrong crash sample will be saved.

