### PR TITLE
Prevent target from unexpected closing TSL_FD

### DIFF
--- a/accel/tcg/cpu-exec.c
+++ b/accel/tcg/cpu-exec.c
@@ -58,11 +58,6 @@
  * VARIOUS AUXILIARY STUFF *
  ***************************/
 
-/* We use one additional file descriptor to relay "needs translation"
-   messages between the child and the fork server. */
-
-#define TSL_FD (FORKSRV_FD - 1)
-
 /* This is equivalent to afl-as.h: */
 
 static unsigned char

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -8381,6 +8381,8 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
         return ret;
 #endif
     case TARGET_NR_close:
+        if (unlikely(arg1 == TSL_FD))
+	    return 0x00;
         fd_trans_unregister(arg1);
         return get_errno(close(arg1));
 

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -8382,7 +8382,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
 #endif
     case TARGET_NR_close:
         if (unlikely(arg1 == TSL_FD))
-	    return 0x00;
+            return 0x00;
         fd_trans_unregister(arg1);
         return get_errno(close(arg1));
 

--- a/qemuafl/common.h
+++ b/qemuafl/common.h
@@ -37,8 +37,12 @@
 #include "imported/config.h"
 #include "imported/types.h"
 #include "imported/cmplog.h"
-
 #include "api.h"
+
+/* We use one additional file descriptor to relay "needs translation"
+   messages between the child and the fork server. */
+
+#define TSL_FD (FORKSRV_FD - 1)
 
 #define AFL_G2H g2h_untagged
 


### PR DESCRIPTION
Once upon a time I met target which open `/proc/self/fd` and loop throe all opened fd's calling sys_close() on each. 

As a result cache subsystem was broken.

This small patch should prevent such behavior for guest vCPU. 