### PR TITLE
Fix PPC64 usage of afl_entry_point and TARGET_LONG_BITS

### DIFF
--- a/qemuafl/api.h
+++ b/qemuafl/api.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-#if defined(TARGET_MIPS64) || defined(TARGET_AARCH64) || defined(TARGET_X86_64)
+#if defined(TARGET_MIPS64) || defined(TARGET_AARCH64) || defined(TARGET_X86_64) || defined(TARGET_PPC64)
 # define TARGET_LONG_BITS 64
 #else
 # define TARGET_LONG_BITS 32


### PR DESCRIPTION
The old implementation of PPC64 has been broken by changes of the context.
This patch updates the assignment of the afl_entry_point and sets TARGET_LONG_BITS accordingly.