### PR TITLE
Add dlerror message on dlopen failure

### DIFF
--- a/accel/tcg/cpu-exec.c
+++ b/accel/tcg/cpu-exec.c
@@ -517,8 +517,9 @@ void afl_setup(void) {
     void *plib = dlopen(getenv("AFL_QEMU_PERSISTENT_HOOK"), RTLD_NOW);
     if (!plib) {
 
-      fprintf(stderr, "[AFL] ERROR: invalid AFL_QEMU_PERSISTENT_HOOK=%s\n",
-              getenv("AFL_QEMU_PERSISTENT_HOOK"));
+      fprintf(stderr, "[AFL] ERROR: invalid AFL_QEMU_PERSISTENT_HOOK=%s - %s\n",
+              getenv("AFL_QEMU_PERSISTENT_HOOK"),
+              dlerror());
       exit(1);
 
     }


### PR DESCRIPTION
Add dlerror output to error message when dlopen fails to load `QEMU_PERSISTENT_HOOK`.

Closes #43 