### PR TITLE
RISCV64 fix

### DIFF
--- a/qemuafl/api.h
+++ b/qemuafl/api.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-#if defined(TARGET_MIPS64) || defined(TARGET_AARCH64) || defined(TARGET_X86_64) || defined(TARGET_PPC64)
+#if defined(TARGET_MIPS64) || defined(TARGET_AARCH64) || defined(TARGET_X86_64) || defined(TARGET_PPC64) || defined(TARGET_RISCV64)
 # define TARGET_LONG_BITS 64
 #else
 # define TARGET_LONG_BITS 32


### PR DESCRIPTION
Hello! I successfully built and ran afl-fuzz in qemu mode on riscv64. Perhaps this fix will be useful.

![2023-04-13_17-58-qemu](https://user-images.githubusercontent.com/60780909/231807003-2e50f25d-01d3-40ed-a676-a03f1cb4ff24.png)
