### PR TITLE
Correctly detect when gdbus-codegen is missing

### DIFF
--- a/configure
+++ b/configure
@@ -5684,7 +5684,9 @@ if test "$gio" = "yes" ; then
     echo "CONFIG_GIO=y" >> $config_host_mak
     echo "GIO_CFLAGS=$gio_cflags" >> $config_host_mak
     echo "GIO_LIBS=$gio_libs" >> $config_host_mak
-    echo "GDBUS_CODEGEN=$gdbus_codegen" >> $config_host_mak
+    if [ -n "$gdbus_codegen" ]; then
+        echo "GDBUS_CODEGEN=$gdbus_codegen" >> $config_host_mak
+    fi
 fi
 echo "CONFIG_TLS_PRIORITY=\"$tls_priority\"" >> $config_host_mak
 if test "$gnutls" = "yes" ; then


### PR DESCRIPTION
The problem arises when the `gdbus-codegen` binary exists but the pkg-config file for it (`dbus-glib-1.pc`) doesnt.

`configure` lines 3328 - 3334:
```sh
    gdbus_codegen=$($pkg_config --variable=gdbus_codegen gio-2.0)
    if [ ! -x "$gdbus_codegen" ]; then
        gdbus_codegen=
    fi
```

So if `pkg-config` can't find `gdbus_codegen`, `$gdbus_codegen` will be blank. It is used again on line 5687:
```sh
if test "$gio" = "yes" ; then
    echo "CONFIG_GIO=y" >> $config_host_mak
    echo "GIO_CFLAGS=$gio_cflags" >> $config_host_mak
    echo "GIO_LIBS=$gio_libs" >> $config_host_mak
    echo "GDBUS_CODEGEN=$gdbus_codegen" >> $config_host_mak
fi
```

The problem is that it doesn't check whether `$gdbus_codegen` is blank or not. So now we have `GDBUS_CODEGEN` set to `""` in `config_host`, which gets passed on to meson.

`tests/qtest/meson.build` lines 70 - 80:
```meson
dbus_daemon = find_program('dbus-daemon', required: false)
if dbus_daemon.found() and config_host.has_key('GDBUS_CODEGEN')
  # Temporarily disabled due to Patchew failures:
  #qtests_i386 += ['dbus-vmstate-test']
  dbus_vmstate1 = custom_target('dbus-vmstate description',
                                output: ['dbus-vmstate1.h', 'dbus-vmstate1.c'],
                                input: files('dbus-vmstate1.xml'),
                                command: [config_host['GDBUS_CODEGEN'],
                                          '@INPUT@',
                                          '--interface-prefix', 'org.qemu',
                                          '--generate-c-code', '@BASENAME@']).to_list()
```

`config_host.has_key('GDBUS_CODEGEN')` evaluates to true because the key does exist - it's just blank. `dbus_daemon.found()` also evaluates to true because the relevant binary _does_ exist - it's just the `.pc` file that's missing. Then `custom_target` tries to run this blank executable path, leading to this error when `configure` is run:
```
Program dbus-daemon found: YES (/usr/bin/dbus-daemon)

../tests/qtest/meson.build:74:18: ERROR: Program '' not found or not executable
```

The PR fixes this by only putting `GDBUS_CODEGEN` into `$config_host_mak` if it's not blank.

# Reproducing the error
On debian, install `libglib2.0-dev-bin` (which gives you `/usr/bin/gdbus-codegen`) but not `libdbus-glib-1-dev` (which gives you `/usr/lib/x86_64-linux-gnu/pkgconfig/dbus-glib-1.pc`) and run `configure`.

Here was the exact configure command I used, although I don't think it's necessary to reproduce the bug:
```
$ PKG_CONFIG_LIBDIR=/usr/aarch64-linux-gnu/lib/pkgconfig ../configure --audio-drv-list= --disable-blobs --disable-bochs --disable-brlapi --disable-bsd-user --disable-bzip2 --disable-cap-ng --disable-cloop --disable-curl --disable-curses --disable-dmg --disable-fdt --disable-gcrypt --disable-glusterfs --disable-gnutls --disable-gtk --disable-guest-agent --disable-iconv --disable-libiscsi --disable-libnfs --disable-libssh --disable-libusb --disable-linux-aio --disable-live-block-migration --disable-lzo --disable-nettle --disable-numa --disable-opengl --disable-parallels --disable-plugins --disable-qcow1 --disable-qed --disable-rbd --disable-rdma --disable-replication --disable-sdl --disable-seccomp --disable-sheepdog --disable-smartcard --disable-snappy --disable-spice --disable-system --disable-tools --disable-tpm --disable-usb-redir --disable-vde --disable-vdi --disable-vhost-crypto --disable-vhost-kernel --disable-vhost-net --disable-vhost-scsi --disable-vhost-user --disable-vhost-vdpa --disable-vhost-vsock --disable-virglrenderer --disable-virtfs --disable-vnc --disable-vnc-jpeg --disable-vnc-png --disable-vnc-sasl --disable-vte --disable-vvfat --disable-xen --disable-xen-pci-passthrough --disable-xfsctl --target-list=aarch64-linux-user --without-default-devices --static --disable-pie --extra-cflags=-DAFL_QEMU_STATIC_BUILD=1 --disable-debug-info --disable-debug-mutex --disable-debug-tcg --disable-qom-cast-debug --disable-stack-protector --disable-werror --disable-docs --disable-capstone --cross-prefix=aarch64-linux-gnu- --interp-prefix=/usr/aarch64-linux-gnu/
```
I was trying to cross-compile qemuafl which is why it's such a mess.

Let me know if something is off, I'm a bit new to this PR stuff.