### PR TITLE
Implement AFL persistent exit for mips

### DIFF
--- a/linux-user/mips/cpu_loop.c
+++ b/linux-user/mips/cpu_loop.c
@@ -84,6 +84,18 @@ void cpu_loop(CPUMIPSState *env)
 
         switch(trapnr) {
         case EXCP_SYSCALL:
+            if (
+                persistent_exits &&
+                (
+                     env->active_tc.gpr[2] == TARGET_NR_exit_group ||
+                     // uclibc may use the following signal instead of
+                     // exit_group:
+                     env->active_tc.gpr[2] == TARGET_NR_exit
+                )
+            ) {
+              env->active_tc.PC = afl_persistent_addr;
+              continue;
+            }
             env->active_tc.PC += 4;
 # ifdef TARGET_ABI_MIPSO32
             syscall_num = env->active_tc.gpr[2] - 4000;


### PR DESCRIPTION
This adds support for the AFL_QEMU_PERSISTENT_EXITS environment variable inside MIPS programs. The code mostly is taken from the other architecture's `cpu_loop.c` files.

I've further added a test to see if the system call number is `TARGET_NR_exit`.

The embedded target I've used AFL++ on does not use the more common `exit_group` system call. `exit()` in uclibc uses the exit system call. See the `uclibc-ng` version 1.0.6 source here:

https://elixir.bootlin.com/uclibc-ng/v1.0.6/source/libc/sysdeps/linux/common/_exit.c#L28

I've tested this functionality by writing a C program that calls `exit(0)` at the end of its `main()` function. When you run afl-fuzz, it correctly recognizes the end of the loop and restarts.

You can also run qemu with `AFL_QEMU_PERSISTENT_ADDR` and `AFL_QEMU_PERSISTENT_EXITS` set directly. QEMU returns to the starting point when the program calls `exit(0)`.

This is a small C program, inspired by `test-instr.c` that you can use to verify the behavior:

```c
int main(int argc, char **argv) {
  int   cnt;
  char  buff[8];

  fgets(buff, sizeof(buff) - 1, stdin);

  buff[sizeof(buff) - 1] = 0;

  printf("Looks like a %s to me!\n", buff);

  exit(0);
  return 0;
}
```