### PR TITLE
Fix: Update u-boot repository URLs to GitHub

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,7 +21,7 @@
 	url = https://gitlab.com/qemu-project/dtc.git
 [submodule "roms/u-boot"]
 	path = roms/u-boot
-	url = https://gitlab.com/qemu-project/u-boot.git
+	url = https://github.com/qemu/u-boot.git
 [submodule "roms/skiboot"]
 	path = roms/skiboot
 	url = https://gitlab.com/qemu-project/skiboot.git
@@ -39,7 +39,7 @@
 	url = https://gitlab.com/qemu-project/seabios-hppa.git
 [submodule "roms/u-boot-sam460ex"]
 	path = roms/u-boot-sam460ex
-	url = https://gitlab.com/qemu-project/u-boot-sam460ex.git
+	url = https://github.com/qemu/u-boot-sam460ex.git
 [submodule "tests/fp/berkeley-testfloat-3"]
 	path = tests/fp/berkeley-testfloat-3
 	url = https://gitlab.com/qemu-project/berkeley-testfloat-3.git


### PR DESCRIPTION
The Gitlab URLs for the `u-boot` and `u-boot-sam460ex` repositories are no longer active, causing fetch operations to fail.
This PR updates them to point to the official qemu organization repositories on GitHub.