### PR TITLE
Remove bundled Meson

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -58,9 +58,6 @@
 [submodule "roms/qboot"]
 	path = roms/qboot
 	url = https://gitlab.com/qemu-project/qboot.git
-[submodule "meson"]
-	path = meson
-	url = https://gitlab.com/qemu-project/meson.git
 [submodule "roms/vbootrom"]
 	path = roms/vbootrom
 	url = https://gitlab.com/qemu-project/vbootrom.git


### PR DESCRIPTION
Meson >= 0.55.3 is available on all supported distro releases.

Split from GH-64.