### PR TITLE
Remove SLOF submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "roms/seabios"]
 	path = roms/seabios
 	url = https://gitlab.com/qemu-project/seabios.git/
-[submodule "roms/SLOF"]
-	path = roms/SLOF
-	url = https://gitlab.com/qemu-project/SLOF.git
 [submodule "roms/ipxe"]
 	path = roms/ipxe
 	url = https://gitlab.com/qemu-project/ipxe.git


### PR DESCRIPTION
Slimline Open Firmware is used as partition firmware for PowerPC machines running on KVM/QEMU.  AFL++ does not use QEMU for system emulation.

Split from GH-64.