### PR TITLE
cpu-exec: don't deref NULL shared_buf_len in file-input persistent-hook mode

### DIFF
--- a/accel/tcg/cpu-exec.c
+++ b/accel/tcg/cpu-exec.c
@@ -1425,8 +1425,10 @@ void afl_persistent_iter(CPUArchState *env) {
     if (persistent_save_gpr && afl_persistent_hook_ptr) {
 
       struct api_regs hook_regs = saved_regs;
-      afl_persistent_hook_ptr(&hook_regs, guest_base, shared_buf,
-                              *shared_buf_len);
+      /* file-input mode (init() returned 0) leaves shared_buf_len NULL. */
+      afl_persistent_hook_ptr(&hook_regs, guest_base,
+                              sharedmem_fuzzing ? shared_buf : NULL,
+                              sharedmem_fuzzing ? *shared_buf_len : 0);
       afl_restore_regs(&hook_regs, env);
 
     }
@@ -1471,8 +1473,10 @@ void afl_persistent_loop(CPUArchState *env) {
       if (afl_persistent_hook_ptr) {
 
         struct api_regs hook_regs = saved_regs;
-        afl_persistent_hook_ptr(&hook_regs, guest_base, shared_buf,
-                                *shared_buf_len);
+        /* same NULL guard as above (file-input mode). */
+        afl_persistent_hook_ptr(&hook_regs, guest_base,
+                                sharedmem_fuzzing ? shared_buf : NULL,
+                                sharedmem_fuzzing ? *shared_buf_len : 0);
         afl_restore_regs(&hook_regs, env);
 
       }


### PR DESCRIPTION
When `afl_persistent_hook_init()` returns 0 (file-input mode), `cpu-exec.c` unconditionally derefs NULL `*shared_buf_len` and SEGVs inside QEMU on every iteration aborting afl-fuzz with the misleading `[AFL] ERROR: no persistent iteration executed` — reproduces in seconds with a PPC32 hello-world target plus a no-op hook whose `init()` returns 0. 

Fix: pass `NULL`/`0` to the hook when `sharedmem_fuzzing` is false at both call sites; post-fix afl-fuzz iterates cleanly and shared-mem mode (`init()` returns 1) is unchanged.
