### PR TITLE
qasan: fix context shadow stack bounds

### DIFF
--- a/accel/tcg/tcg-runtime.c
+++ b/accel/tcg/tcg-runtime.c
@@ -479,11 +479,20 @@ __thread struct shadow_stack qasan_shadow_stack;
 #include <sys/types.h>
 #include <sys/syscall.h>
 
-void asan_giovese_populate_context(struct call_context* ctx, target_ulong pc) {
+void asan_giovese_populate_context(struct call_context *ctx, target_ulong pc) {
 
-  ctx->size = MIN(qasan_shadow_stack.size, qasan_max_call_stack -1) +1;
-  ctx->addresses = calloc(sizeof(void*), ctx->size);
-  
+  int stack_entries = 0;
+
+  if (qasan_shadow_stack.size > 0) {
+
+    stack_entries = MIN(qasan_shadow_stack.size, qasan_max_call_stack - 1);
+
+  }
+
+  ctx->size = stack_entries + 1;
+  ctx->addresses = calloc(ctx->size, sizeof(*ctx->addresses));
+  if (!ctx->addresses) return;
+
 #ifdef __NR_gettid
   ctx->tid = (uint32_t)syscall(__NR_gettid);
 #else
@@ -494,19 +503,23 @@ void asan_giovese_populate_context(struct call_context* ctx, target_ulong pc) {
 #endif
 
   ctx->addresses[0] = pc;
-  
-  if (qasan_shadow_stack.size <= 0) return; //can be negative when pop does not find nothing
-  
+
+  if (qasan_shadow_stack.size <= 0 || !qasan_shadow_stack.first) return;
+
   int i, j = 1;
-  for (i = qasan_shadow_stack.first->index -1; i >= 0 && j < qasan_max_call_stack; --i)
+
+  for (i = qasan_shadow_stack.first->index - 1; i >= 0 && j < ctx->size; --i)
     ctx->addresses[j++] = qasan_shadow_stack.first->buf[i];
 
-  struct shadow_stack_block* b = qasan_shadow_stack.first->next;
-  while (b && j < qasan_max_call_stack) {
-  
-    for (i = SHADOW_BK_SIZE-1; i >= 0; --i)
+  struct shadow_stack_block *b = qasan_shadow_stack.first->next;
+
+  while (b && j < ctx->size) {
+
+    for (i = SHADOW_BK_SIZE - 1; i >= 0 && j < ctx->size; --i)
       ctx->addresses[j++] = b->buf[i];
-  
+
+    b = b->next;
+
   }
 
 }


### PR DESCRIPTION
## Summary

This PR fixes bounds handling in `asan_giovese_populate_context()`.

## Problem

`ctx->addresses` is allocated with `ctx->size` entries, but the context
population loops used `qasan_max_call_stack` as the write bound. When
`ctx->size` is smaller than `qasan_max_call_stack`, this may write past the
allocated buffer.

In addition, `qasan_shadow_stack.size` may be zero or negative, but it was used
to compute `ctx->size` before being checked. This could result in an invalid
context size followed by a write to `ctx->addresses[0]`.

The loop over shadow stack blocks also missed advancing to the next block.

## Changes

- Clamp empty or negative shadow stack size to one context entry for `pc`.
- Allocate `ctx->addresses` using `ctx->size`.
- Use `ctx->size` as the write bound.
- Add bounds checks inside the block-copy loop.
- Advance to the next shadow stack block.

## Testing

Tested from the AFL++ parent repository with:

```bash
make code-format
make clean
make distrib -j$(nproc)
make tests